### PR TITLE
Update to latest version of Jade

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/sonewman/jade-stream",
   "dependencies": {
-    "jade": "~0.35.0"
+    "jade": "^1.9.1"
   },
   "devDependencies": {
     "tap": "~0.4.6"

--- a/test/index.jade
+++ b/test/index.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   body
     h1= header


### PR DESCRIPTION
As we're going from Jade 0.x.x to 1.x.x you'd do well to bump the this package version to 1.0.0. Things will likely break for anyone using this module ^0.1.1 should this get merged.
